### PR TITLE
Rename vendor to Rollerworks

### DIFF
--- a/.gush.yml
+++ b/.gush.yml
@@ -1,5 +1,5 @@
 # Gush configuration file, any comments will be lost.
-meta-header: "This file is part of the Park-Manager AppSectioningBundle package.\n\n(c) Sebastiaan Stok <s.stok@rollerscapes.net>\n\nThis source file is subject to the MIT license that is bundled\nwith this source code in the file LICENSE."
+meta-header: "This file is part of the Rollerworks AppSectioningBundle package.\n\n(c) Sebastiaan Stok <s.stok@rollerscapes.net>\n\nThis source file is subject to the MIT license that is bundled\nwith this source code in the file LICENSE."
 table-pr:
     bug_fix: ['Bug Fix?', 'no']
     new_feature: ['New Feature?', 'no']
@@ -16,7 +16,7 @@ pr_type:
     - security
 repo_adapter: github
 issue_tracker: github
-repo_org: park-manager
+repo_org: rollerworks
 repo_name: app-sectioning-bundle
-issue_project_org: park-manager
+issue_project_org: rollerworks
 issue_project_name: app-sectioning-bundle

--- a/.php_cs
+++ b/.php_cs
@@ -1,7 +1,7 @@
 <?php
 
 $header = <<<EOF
-This file is part of the Park-Manager AppSectioningBundle package.
+This file is part of the Rollerworks AppSectioningBundle package.
 
 (c) Sebastiaan Stok <s.stok@rollerscapes.net>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Park-Manager AppSectioning configurator
+Rollerworks AppSectioning configurator
 =======================================
 
 The AppSectioning configurator helps with separating your Symfony application
@@ -26,10 +26,10 @@ used will overwrite the other one (without warning).
 
 This bundle is best used for multi-section applications and not decoupled bundles.
 
-Park-Manager
+Rollerworks
 ------------
 
-Park-Manager is your friend in hosting software. Visit [Park-Manager.com](http://www.park-manager.com)
+Rollerworks is your friend in hosting software. Visit [Rollerworks.com](http://www.rollerworks.com)
 
 Requirements
 ------------

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "park-manager/app-sectioning-bundle",
+    "name": "rollerworks/app-sectioning-bundle",
     "description": "Configuration helper for separating your Symfony application into multiple sections",
     "type": "symfony-bundle",
     "license": "MIT",
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.0",
         "symfony/framework-bundle": "^2.8|^3.0"
     },
     "require-dev": {
@@ -18,12 +18,12 @@
     },
     "autoload": {
         "psr-4": {
-            "ParkManager\\Bundle\\AppSectioning\\": "src/"
+            "Rollerworks\\Bundle\\AppSectioning\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "ParkManager\\Bundle\\AppSectioning\\Tests\\": "tests/"
+            "Rollerworks\\Bundle\\AppSectioning\\Tests\\": "tests/"
         }
     }
 }

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -19,7 +19,7 @@ namespace Acme\FrontendBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use ParkManager\Bundle\AppSectioning\DependencyInjection\SectioningConfigurator;
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningConfigurator;
 
 class DatabaseConfiguration implements ConfigurationInterface
 {
@@ -57,7 +57,7 @@ namespace Acme\FrontendBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
-use ParkManager\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
 
 class AcmeFrontendExtension extends ConfigurableExtension
 {
@@ -120,4 +120,4 @@ Placeholders for eg. `{_locale}` or more tld's/IP nets in the host, are not supp
 *A negative lookahead regex pattern must only be used when there are sections that match,
 else `^/(?!(user)/)` is going to fail with `/user/` in the backend section (with it a different host).*
 
-See also [Add placeholder support for prefix and host in the issue tracker](https://github.com/park-manager/app-sectioning-bundle/issues/1)
+See also [Add placeholder support for prefix and host in the issue tracker](https://github.com/rollerworks/app-sectioning-bundle/issues/1)

--- a/doc/install.md
+++ b/doc/install.md
@@ -5,7 +5,7 @@ Open a command console, enter your project directory and execute the
 following command to download the latest stable version of this bundle:
 
 ```bash
-$ php composer.phar require park-manager/app-sectioning-bundle
+$ php composer.phar require rollerworks/app-sectioning-bundle
 ```
 
 This command requires you to have Composer installed globally, as explained
@@ -26,7 +26,7 @@ class AppKernel extends Kernel
     {
         $bundles = [
             // ...
-            new ParkManager\Bundle\AppSectioning\ParkManagerAppSectioningBundle(),
+            new Rollerworks\Bundle\AppSectioning\RollerworksAppSectioningBundle(),
             // ...
         ];
 
@@ -37,6 +37,6 @@ class AppKernel extends Kernel
 }
 ```
 
-You are now ready to use the Park-Manager AppSectioning configurator bundle.
+You are now ready to use the Rollerworks AppSectioning configurator bundle.
 
 Continue to [Configuration](configuration.md) to learn more about usage and implementation.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
     </php>
 
     <testsuites>
-        <testsuite name="ParkManager AppSectioningBundle Test Suite">
+        <testsuite name="Rollerworks AppSectioningBundle Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>

--- a/src/AppSectionsValidator.php
+++ b/src/AppSectionsValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning;
+namespace Rollerworks\Bundle\AppSectioning;
 
-use ParkManager\Bundle\AppSectioning\Exception\ValidatorException;
+use Rollerworks\Bundle\AppSectioning\Exception\ValidatorException;
 
 /**
  * The AppSectionsValidator validates whether the provided Application sections

--- a/src/DependencyInjection/AppSectionExtension.php
+++ b/src/DependencyInjection/AppSectionExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioning\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/DependencyInjection/Compiler/AppSectionsPass.php
+++ b/src/DependencyInjection/Compiler/AppSectionsPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,11 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\DependencyInjection\Compiler;
+namespace Rollerworks\Bundle\AppSectioning\DependencyInjection\Compiler;
 
-use ParkManager\Bundle\AppSectioning\AppSectionsValidator;
-use ParkManager\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
-use ParkManager\Bundle\AppSectioning\SectionsConfigurator;
+use Rollerworks\Bundle\AppSectioning\AppSectionsValidator;
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
+use Rollerworks\Bundle\AppSectioning\SectionsConfigurator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 

--- a/src/DependencyInjection/SectioningConfigurator.php
+++ b/src/DependencyInjection/SectioningConfigurator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace ParkManager\Bundle\AppSectioning\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioning\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/DependencyInjection/SectioningFactory.php
+++ b/src/DependencyInjection/SectioningFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioning\DependencyInjection;
 
-use ParkManager\Bundle\AppSectioning\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 

--- a/src/Exception/ValidatorException.php
+++ b/src/Exception/ValidatorException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\Exception;
+namespace Rollerworks\Bundle\AppSectioning\Exception;
 
 final class ValidatorException extends \LogicException
 {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="park_manager.app_section.route_loader" class="ParkManager\Bundle\AppSectioning\Routing\AppSectionRouteLoader" public="false">
+        <service id="park_manager.app_section.route_loader" class="Rollerworks\Bundle\AppSectioning\Routing\AppSectionRouteLoader" public="false">
             <tag name="routing.loader" />
             <argument type="service" id="routing.loader" />
             <argument type="collection" /> <!-- Gets populated by the AppSectionsPass -->

--- a/src/RollerworksAppSectioningBundle.php
+++ b/src/RollerworksAppSectioningBundle.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,14 +9,14 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning;
+namespace Rollerworks\Bundle\AppSectioning;
 
-use ParkManager\Bundle\AppSectioning\DependencyInjection\AppSectionExtension;
-use ParkManager\Bundle\AppSectioning\DependencyInjection\Compiler\AppSectionsPass;
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\AppSectionExtension;
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\Compiler\AppSectionsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class ParkManagerAppSectioningBundle extends Bundle
+class RollerworksAppSectioningBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {

--- a/src/Routing/AppSectionRouteLoader.php
+++ b/src/Routing/AppSectionRouteLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\Routing;
+namespace Rollerworks\Bundle\AppSectioning\Routing;
 
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Config\Loader\LoaderInterface;

--- a/src/SectionConfiguration.php
+++ b/src/SectionConfiguration.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning;
+namespace Rollerworks\Bundle\AppSectioning;
 
 final class SectionConfiguration
 {

--- a/src/SectionsConfigurator.php
+++ b/src/SectionsConfigurator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning;
+namespace Rollerworks\Bundle\AppSectioning;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\RequestMatcher;

--- a/tests/AppSectionsValidatorTest.php
+++ b/tests/AppSectionsValidatorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,11 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\Tests;
+namespace Rollerworks\Bundle\AppSectioning\Tests;
 
-use ParkManager\Bundle\AppSectioning\AppSectionsValidator;
-use ParkManager\Bundle\AppSectioning\Exception\ValidatorException;
-use ParkManager\Bundle\AppSectioning\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioning\AppSectionsValidator;
+use Rollerworks\Bundle\AppSectioning\Exception\ValidatorException;
+use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
 
 final class AppSectionsValidatorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/DependencyInjection/Compiler/AppSectionsPassTest.php
+++ b/tests/DependencyInjection/Compiler/AppSectionsPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,13 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\Tests\DependencyInjection\Compiler;
+namespace Rollerworks\Bundle\AppSectioning\Tests\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
-use ParkManager\Bundle\AppSectioning\DependencyInjection\Compiler\AppSectionsPass;
-use ParkManager\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
-use ParkManager\Bundle\AppSectioning\Exception\ValidatorException;
-use ParkManager\Bundle\AppSectioning\Routing\AppSectionRouteLoader;
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\Compiler\AppSectionsPass;
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
+use Rollerworks\Bundle\AppSectioning\Exception\ValidatorException;
+use Rollerworks\Bundle\AppSectioning\Routing\AppSectionRouteLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;

--- a/tests/DependencyInjection/SectioningFactoryTest.php
+++ b/tests/DependencyInjection/SectioningFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,11 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\Tests\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioning\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractContainerBuilderTestCase;
-use ParkManager\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
-use ParkManager\Bundle\AppSectioning\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
+use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
 
 final class SectioningFactoryTest extends AbstractContainerBuilderTestCase
 {

--- a/tests/Routing/AppSectionRouteLoaderTest.php
+++ b/tests/Routing/AppSectionRouteLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\Tests\Routing;
+namespace Rollerworks\Bundle\AppSectioning\Tests\Routing;
 
-use ParkManager\Bundle\AppSectioning\Routing\AppSectionRouteLoader;
+use Rollerworks\Bundle\AppSectioning\Routing\AppSectionRouteLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;

--- a/tests/SectionConfigurationTest.php
+++ b/tests/SectionConfigurationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\Tests;
+namespace Rollerworks\Bundle\AppSectioning\Tests;
 
-use ParkManager\Bundle\AppSectioning\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
 
 final class SectionConfigurationTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/SectionsConfiguratorTest.php
+++ b/tests/SectionsConfiguratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Park-Manager AppSectioningBundle package.
+ * This file is part of the Rollerworks AppSectioningBundle package.
  *
  * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
  *
@@ -9,10 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-namespace ParkManager\Bundle\AppSectioning\Tests;
+namespace Rollerworks\Bundle\AppSectioning\Tests;
 
-use ParkManager\Bundle\AppSectioning\SectionConfiguration;
-use ParkManager\Bundle\AppSectioning\SectionsConfigurator;
+use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioning\SectionsConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Bug Fix?     |no |
|New Feature? |no |
|BC Breaks?   |yes|
|Deprecations?|no |
|Fixed Tickets|   |
|License      |MIT|
                   

Park-Manager projects are all MPL v.2.0. And this is better suited in Rollerworks.