### PR TITLE
Add support for placeholders in host

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/framework-bundle": "^2.8|^3.0"
+        "symfony/framework-bundle": "^2.8|^3.0",
+        "icomefromthenet/reverse-regex": "^0.0.6.3"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.2.6",

--- a/src/Exception/ValidatorException.php
+++ b/src/Exception/ValidatorException.php
@@ -21,7 +21,7 @@ final class ValidatorException extends \LogicException
 
         foreach ($failedSections as $name => list($host, $prefix, $conflicts)) {
             $errors[] = sprintf(
-                'AppSection(s) "%s" conflict with "%s", all have the same host "%s" and prefix "%s" configured.',
+                'AppSection(s) "%s" conflict with "%s", all have the same host pattern "%s" and prefix "%s" configured.',
                 implode('", "', $conflicts),
                 $name,
                 $host,

--- a/src/RegexEqualityChecker.php
+++ b/src/RegexEqualityChecker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks AppSectioningBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\AppSectioning;
+
+use ReverseRegex\Generator\Scope;
+use ReverseRegex\Lexer;
+use ReverseRegex\Parser;
+use ReverseRegex\Random\SimpleRandom;
+
+/**
+ * @internal
+ */
+final class RegexEqualityChecker
+{
+    public static function equals(string $first, string $second): bool
+    {
+        if ($first === $second) {
+            return true;
+        }
+
+        $first = preg_replace('/\(\?P<[a-z_0-9]+>/', '(', $first);
+        $parser = new Parser(new Lexer($first), new Scope(), new Scope());
+        $random = new SimpleRandom(1);
+
+        for ($i = 1; $i < 10; ++$i) {
+            $random->seed($i);
+            $result = '';
+
+            if (preg_match($second, $parser->parse()->getResult()->generate($result, $random))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Routing/AppSectionRouteLoader.php
+++ b/src/Routing/AppSectionRouteLoader.php
@@ -77,16 +77,14 @@ final class AppSectionRouteLoader extends Loader
 
         /** @var RouteCollection $collection */
         $collection = $this->loader->load($parts['resource'], '' === $parts['type'] ? null : $parts['type']);
+        $section = $this->sections[$parts['section']];
 
         // Configure the section information for all imported routes.
         // N.B. this needs to be called 'after' the importing!
-        $collection->addPrefix($this->sections[$parts['section']]['prefix']);
+        $collection->addPrefix($section['prefix']);
 
         if (isset($this->sections[$parts['section']]['host'])) {
-            $section = $this->sections[$parts['section']];
-
-            $collection->setHost('{host}', ['host' => $section['host']]);
-            $collection->addRequirements($section['requirements']);
+            $collection->setHost($section['host'], $section['host_defaults'], $section['host_requirements']);
         }
 
         return $collection;

--- a/tests/DependencyInjection/Compiler/AppSectionsPassTest.php
+++ b/tests/DependencyInjection/Compiler/AppSectionsPassTest.php
@@ -73,21 +73,19 @@ final class AppSectionsPassTest extends AbstractCompilerPassTestCase
                 'prefix' => '/',
                 'host' => 'example.com',
                 'host_pattern' => '^example\.com$',
-                'requirements' => [
-                    'host' => '^example\.com$',
-                ],
+                'requirements' => [],
                 'service_prefix' => 'acme.section',
                 'path' => '^/(?!(backend)/)',
+                'defaults' => [],
             ],
             'backend' => [
                 'prefix' => 'backend/',
                 'host' => 'example.com',
                 'host_pattern' => '^example\.com$',
-                'requirements' => [
-                    'host' => '^example\.com$',
-                ],
+                'requirements' => [],
                 'service_prefix' => 'acme.section',
                 'path' => '^/backend/',
+                'defaults' => [],
             ],
         ]);
     }
@@ -149,8 +147,8 @@ final class AppSectionsPassTest extends AbstractCompilerPassTestCase
 
         $this->expectException(ValidatorException::class);
         $this->expectExceptionMessage(
-            'AppSection(s) "backend" conflict with "frontend", all have the same host "example.com" '.
-            'and prefix "/" configured.'
+            'AppSection(s) "backend" conflict with "frontend", all have the same host pattern '.
+            '"^example\.com$" and prefix "/" configured.'
         );
 
         $this->compile();

--- a/tests/RegexEqualityCheckerTest.php
+++ b/tests/RegexEqualityCheckerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks AppSectioningBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\AppSectioning\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Bundle\AppSectioning\RegexEqualityChecker;
+
+final class RegexEqualityCheckerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_equals_for_same_regex()
+    {
+        self::assertTrue(RegexEqualityChecker::equals('foobar', 'foobar'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_equals_regex_with_same_matches()
+    {
+        self::assertTrue(RegexEqualityChecker::equals('^foo(bar)$', '#^foobar$#'));
+        self::assertTrue(RegexEqualityChecker::equals('^(foo)(bar)$', '#^foobar$#'));
+        self::assertTrue(RegexEqualityChecker::equals('^(foo)(bar)?$', '#^foobar$#'));
+        self::assertTrue(RegexEqualityChecker::equals('^(foo)(bar)?$', '#^foob?ar$#'));
+        self::assertTrue(RegexEqualityChecker::equals('^(foo)(bar)?$', '#^foo[b]?ar$#'));
+        self::assertTrue(RegexEqualityChecker::equals('^(foo)(bar)?$', '#^foo[ba]?ar$#'));
+        self::assertTrue(RegexEqualityChecker::equals('^(foo)(bar)?$', '#foob(?=ar)#'));
+        self::assertTrue(RegexEqualityChecker::equals('^foo?$', '#foo(?!bar)#'));
+        self::assertTrue(RegexEqualityChecker::equals('^foo?$', '#foo(?!bar)#'));
+        self::assertTrue(RegexEqualityChecker::equals('^/(?P<tld>app)/$', '#^/app/$#'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_equal_for_regex_with_different_matches()
+    {
+        self::assertFalse(RegexEqualityChecker::equals('foo(?!bar)', '#foobar#'));
+        self::assertFalse(RegexEqualityChecker::equals('^foo$', '#^foobar$#'));
+        self::assertFalse(RegexEqualityChecker::equals('^foobar$', '#^foo$#'));
+    }
+}

--- a/tests/Routing/AppSectionRouteLoaderTest.php
+++ b/tests/Routing/AppSectionRouteLoaderTest.php
@@ -27,12 +27,21 @@ final class AppSectionRouteLoaderTest extends TestCase
     private $loader;
 
     const APP_SECTIONS = [
-        'api' => ['prefix' => 'api/'],
-        'frontend' => ['prefix' => '/'],
+        'api' => [
+            'prefix' => 'api/',
+            'host_requirements' => [],
+            'host_defaults' => [],
+        ],
+        'frontend' => [
+            'prefix' => '/',
+            'host_requirements' => [],
+            'host_defaults' => [],
+        ],
         'backend' => [
             'prefix' => '/',
-            'host' => 'example.com',
-            'requirements' => ['host' => 'example\.com'],
+            'host' => 'example.{tld}',
+            'host_requirements' => ['tld' => 'net|com'],
+            'host_defaults' => ['tld' => 'com'],
         ],
     ];
 
@@ -113,8 +122,8 @@ final class AppSectionRouteLoaderTest extends TestCase
         $routeCollection1->add('frontend_blog', new Route('blog/'));
 
         $routeCollection2 = new RouteCollection();
-        $routeCollection2->add('backend_main', new Route('/', ['host' => 'example.com'], ['host' => 'example\.com'], [], '{host}'));
-        $routeCollection2->add('backend_user', new Route('user/', ['host' => 'example.com'], ['host' => 'example\.com'], [], '{host}'));
+        $routeCollection2->add('backend_main', new Route('/', ['tld' => 'com'], ['tld' => 'net|com'], [], 'example.{tld}'));
+        $routeCollection2->add('backend_user', new Route('user/', ['tld' => 'com'], ['tld' => 'net|com'], [], 'example.{tld}'));
 
         $routeCollection3 = new RouteCollection();
         $routeCollection3->add('frontend_news', new Route('api/news/'));

--- a/tests/SectionConfigurationTest.php
+++ b/tests/SectionConfigurationTest.php
@@ -75,15 +75,6 @@ final class SectionConfigurationTest extends TestCase
     }
 
     /**
-     * @test
-     */
-    public function it_converts_the_host_to_lowercase()
-    {
-        $configuration = (new SectionConfiguration(['prefix' => '/', 'host' => 'Example.Com']))->getConfig();
-        $this->assertEquals('example.com', $configuration['host']);
-    }
-
-    /**
      * This needs to be removed once support is added.
      *
      * @test
@@ -91,21 +82,8 @@ final class SectionConfigurationTest extends TestCase
     public function it_throws_when_placeholders_are_found_prefix()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Placeholders in the "host" and/or "prefix" are not supported yet.');
+        $this->expectExceptionMessage('Placeholders in the "prefix" are not supported.');
 
         new SectionConfiguration(['prefix' => '/{_local}/']);
-    }
-
-    /**
-     * This needs to be removed once support is added.
-     *
-     * @test
-     */
-    public function it_throws_when_placeholders_are_found_host()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Placeholders in the "host" and/or "prefix" are not supported yet.');
-
-        new SectionConfiguration(['prefix' => '/', 'host' => '{locale}.example.com']);
     }
 }

--- a/tests/SectionsConfiguratorTest.php
+++ b/tests/SectionsConfiguratorTest.php
@@ -32,8 +32,24 @@ final class SectionsConfiguratorTest extends TestCase
 
         $this->assertEquals(
             [
-                'frontend' => ['host' => null, 'host_pattern' => null, 'prefix' => 'client/', 'path' => '^/client/', 'service_prefix' => 'acme.section', 'requirements' => []],
-                'backend' => ['host' => null, 'host_pattern' => null, 'prefix' => 'backend/', 'path' => '^/backend/', 'service_prefix' => 'acme.section', 'requirements' => []],
+                'frontend' => [
+                    'host' => null,
+                    'host_pattern' => null,
+                    'prefix' => 'client/',
+                    'path' => '^/client/',
+                    'service_prefix' => 'acme.section',
+                    'requirements' => [],
+                    'defaults' => [],
+                ],
+                'backend' => [
+                    'host' => null,
+                    'host_pattern' => null,
+                    'prefix' => 'backend/',
+                    'path' => '^/backend/',
+                    'service_prefix' => 'acme.section',
+                    'requirements' => [],
+                    'defaults' => [],
+                ],
             ],
             $configurator->exportConfiguration()
         );
@@ -56,7 +72,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'prefix' => '/',
                     'path' => '^/',
                     'service_prefix' => 'acme.section',
-                    'requirements' => ['host' => '^example\.net$'],
+                    'requirements' => [],
+                    'defaults' => [],
                 ],
                 'backend' => [
                     'host' => 'example.com',
@@ -64,7 +81,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'prefix' => '/',
                     'path' => '^/',
                     'service_prefix' => 'acme.section',
-                    'requirements' => ['host' => '^example\.com$'],
+                    'requirements' => [],
+                    'defaults' => [],
                 ],
             ],
             $configurator->exportConfiguration()
@@ -90,6 +108,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'path' => '^/(?!(backend|api)/)',
                     'service_prefix' => 'acme.section',
                     'requirements' => [],
+                    'defaults' => [],
                 ],
                 'backend' => [
                     'host' => null,
@@ -98,6 +117,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'path' => '^/backend/',
                     'service_prefix' => 'acme.section',
                     'requirements' => [],
+                    'defaults' => [],
                 ],
                 'api' => [
                     'host' => null,
@@ -106,6 +126,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'path' => '^/api/',
                     'service_prefix' => 'acme.section',
                     'requirements' => [],
+                    'defaults' => [],
                 ],
             ],
             $configurator->exportConfiguration()
@@ -132,6 +153,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'path' => '^/(?!(backend|api)/)',
                     'service_prefix' => 'acme.section',
                     'requirements' => [],
+                    'defaults' => [],
                 ],
                 'backend' => [
                     'host' => null,
@@ -140,6 +162,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'path' => '^/backend/',
                     'service_prefix' => 'acme.section',
                     'requirements' => [],
+                    'defaults' => [],
                 ],
                 'backend_api' => [
                     'host' => null,
@@ -148,6 +171,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'path' => '^/api/backend/',
                     'service_prefix' => 'acme.section',
                     'requirements' => [],
+                    'defaults' => [],
                 ],
                 'api' => [
                     'host' => null,
@@ -156,6 +180,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'path' => '^/api/(?!(backend)/)',
                     'service_prefix' => 'acme.section',
                     'requirements' => [],
+                    'defaults' => [],
                 ],
             ],
             $configurator->exportConfiguration()
@@ -179,9 +204,10 @@ final class SectionsConfiguratorTest extends TestCase
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
                     'prefix' => '/',
-                    'path' => '^/(?!(backend|api)/)',
+                    'path' => '^/(?!(api|backend)/)',
                     'service_prefix' => 'acme.section',
-                    'requirements' => ['host' => '^example\.com$'],
+                    'requirements' => [],
+                    'defaults' => [],
                 ],
                 'backend' => [
                     'host' => 'example.com',
@@ -189,7 +215,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'prefix' => 'backend/',
                     'path' => '^/backend/',
                     'service_prefix' => 'acme.section',
-                    'requirements' => ['host' => '^example\.com$'],
+                    'requirements' => [],
+                    'defaults' => [],
                 ],
                 'backend_api' => [
                     'host' => 'example.com',
@@ -197,7 +224,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'prefix' => 'api/backend/',
                     'path' => '^/api/backend/',
                     'service_prefix' => 'acme.section',
-                    'requirements' => ['host' => '^example\.com$'],
+                    'requirements' => [],
+                    'defaults' => [],
                 ],
                 'api' => [
                     'host' => 'example.com',
@@ -205,7 +233,62 @@ final class SectionsConfiguratorTest extends TestCase
                     'prefix' => 'api/',
                     'path' => '^/api/(?!(backend)/)',
                     'service_prefix' => 'acme.section',
-                    'requirements' => ['host' => '^example\.com$'],
+                    'requirements' => [],
+                    'defaults' => [],
+                ],
+            ],
+            $configurator->exportConfiguration()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function its_configured_path_excludes_other_sub_paths_in_host_pattern()
+    {
+        $configurator = new SectionsConfigurator();
+        $configurator->set('frontend', new SectionConfiguration(['prefix' => '/', 'host' => 'example.{tld}', 'requirements' => ['tld' => 'com|net'], 'defaults' => ['tld' => 'com']]), 'acme.section');
+        $configurator->set('backend', new SectionConfiguration(['prefix' => 'backend', 'host' => 'example.com']), 'acme.section');
+        $configurator->set('backend_api', new SectionConfiguration(['prefix' => 'api/backend', 'host' => 'example.com']), 'acme.section');
+        $configurator->set('api', new SectionConfiguration(['prefix' => 'api', 'host' => 'example.com']), 'acme.section');
+
+        $this->assertEquals(
+            [
+                'frontend' => [
+                    'host' => 'example.{tld}',
+                    'host_pattern' => '^example\.(?P<tld>com|net)$',
+                    'prefix' => '/',
+                    'path' => '^/(?!(api|backend)/)',
+                    'service_prefix' => 'acme.section',
+                    'requirements' => ['tld' => 'com|net'],
+                    'defaults' => ['tld' => 'com'],
+                ],
+                'backend' => [
+                    'host' => 'example.com',
+                    'host_pattern' => '^example\.com$',
+                    'prefix' => 'backend/',
+                    'path' => '^/backend/',
+                    'service_prefix' => 'acme.section',
+                    'requirements' => [],
+                    'defaults' => [],
+                ],
+                'backend_api' => [
+                    'host' => 'example.com',
+                    'host_pattern' => '^example\.com$',
+                    'prefix' => 'api/backend/',
+                    'path' => '^/api/backend/',
+                    'service_prefix' => 'acme.section',
+                    'requirements' => [],
+                    'defaults' => [],
+                ],
+                'api' => [
+                    'host' => 'example.com',
+                    'host_pattern' => '^example\.com$',
+                    'prefix' => 'api/',
+                    'path' => '^/api/(?!(backend)/)',
+                    'service_prefix' => 'acme.section',
+                    'requirements' => [],
+                    'defaults' => [],
                 ],
             ],
             $configurator->exportConfiguration()
@@ -221,29 +304,44 @@ final class SectionsConfiguratorTest extends TestCase
 
         $configurator = new SectionsConfigurator();
         $configurator->set('frontend', new SectionConfiguration(['prefix' => '/', 'host' => 'example.com']), 'acme.section');
-        $configurator->set('backend', new SectionConfiguration(['prefix' => 'backend', 'host' => 'example.com']), 'park.section');
+        $configurator->set('backend', new SectionConfiguration([
+                'prefix' => 'backend',
+                'host' => 'example.{tld}',
+                'defaults' => ['tld' => 'com'],
+                'requirements' => ['tld' => 'com|net'],
+            ]),
+            'park.section'
+        );
 
         $configurator->registerToContainer($container);
 
         $this->assertTrue($container->hasParameter('acme.section.frontend.host'));
         $this->assertTrue($container->hasParameter('acme.section.frontend.host_pattern'));
+        $this->assertTrue($container->hasParameter('acme.section.frontend.host_requirements'));
+        $this->assertTrue($container->hasParameter('acme.section.frontend.host_defaults'));
         $this->assertTrue($container->hasParameter('acme.section.frontend.prefix'));
         $this->assertTrue($container->hasParameter('acme.section.frontend.path'));
         $this->assertTrue($container->hasDefinition('acme.section.frontend.request_matcher'));
 
         $this->assertTrue($container->hasParameter('park.section.backend.host'));
         $this->assertTrue($container->hasParameter('park.section.backend.host_pattern'));
+        $this->assertTrue($container->hasParameter('park.section.backend.host_requirements'));
+        $this->assertTrue($container->hasParameter('park.section.backend.host_defaults'));
         $this->assertTrue($container->hasParameter('park.section.backend.prefix'));
         $this->assertTrue($container->hasParameter('park.section.backend.path'));
         $this->assertTrue($container->hasDefinition('park.section.backend.request_matcher'));
 
         $this->assertEquals('example.com', $container->getParameter('acme.section.frontend.host'));
         $this->assertEquals('^example\.com$', $container->getParameter('acme.section.frontend.host_pattern'));
+        $this->assertEquals([], $container->getParameter('acme.section.frontend.host_defaults'));
+        $this->assertEquals([], $container->getParameter('acme.section.frontend.host_requirements'));
         $this->assertEquals('/', $container->getParameter('acme.section.frontend.prefix'));
         $this->assertEquals('^/(?!(backend)/)', $container->getParameter('acme.section.frontend.path'));
 
-        $this->assertEquals('example.com', $container->getParameter('park.section.backend.host'));
-        $this->assertEquals('^example\.com$', $container->getParameter('park.section.backend.host_pattern'));
+        $this->assertEquals('example.{tld}', $container->getParameter('park.section.backend.host'));
+        $this->assertEquals('^example\.(?P<tld>com|net)$', $container->getParameter('park.section.backend.host_pattern'));
+        $this->assertEquals(['tld' => 'com'], $container->getParameter('park.section.backend.host_defaults'));
+        $this->assertEquals(['tld' => 'com|net'], $container->getParameter('park.section.backend.host_requirements'));
         $this->assertEquals('backend/', $container->getParameter('park.section.backend.prefix'));
         $this->assertEquals('^/backend/', $container->getParameter('park.section.backend.path'));
 
@@ -253,7 +351,7 @@ final class SectionsConfiguratorTest extends TestCase
 
         $requestMatcherBackend = $container->getDefinition('park.section.backend.request_matcher');
         $this->assertEquals(RequestMatcher::class, $requestMatcherBackend->getClass());
-        $this->assertEquals(['^/backend/', '^example\.com$'], $requestMatcherBackend->getArguments());
+        $this->assertEquals(['^/backend/', '^example\.(?P<tld>com|net)$'], $requestMatcherBackend->getArguments());
 
         // Ensure definitions are correct.
         $container->compile();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1 
| License       | MIT

This finally adds support for using placeholders in the `host` of a section, the prefix needs something different (see comment in #1).