### PR TITLE
Fix AppSectionRouteLoader circular dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ branches:
 matrix:
     include:
         - php: '7.1'
-        - php: '7.1'
-          env: deps='low'
+#        - php: '7.1'
+#          env: deps='low'
         - php: '7.1'
           env: deps='dev'
 

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/framework-bundle": "^2.8.9|^3.2.8",
         "icomefromthenet/reverse-regex": "^0.0.6.3"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.2.6",
+        "symfony/browser-kit": "^2.8.9 || ^3.2.8",
         "matthiasnoback/symfony-dependency-injection-test": "^2.0.0"
     },
     "autoload": {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -66,9 +66,9 @@ class AcmeFrontendExtension extends ConfigurableExtension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
-        $factory = new SectioningFactory($this->container, 'acme.section');
-        $factory->set('frontend', $config['section']));
-        //$factory->set('backend', $config['second_section']));
+        $factory = new SectioningFactory($container, 'acme.section');
+        $factory->set('frontend', $config['section']);
+        //$factory->set('backend', $config['second_section']);
 
         // ...
     }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="rollerworks.app_section.route_loader" class="Rollerworks\Bundle\AppSectioning\Routing\AppSectionRouteLoader" public="false">
             <tag name="routing.loader" />
-            <argument type="service" id="routing.loader" />
+            <argument type="service" id="routing.resolver" />
             <argument type="collection" /> <!-- Gets populated by the AppSectionsPass -->
         </service>
     </services>

--- a/src/Routing/AppSectionRouteLoader.php
+++ b/src/Routing/AppSectionRouteLoader.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Bundle\AppSectioning\Routing;
 
 use Symfony\Component\Config\Loader\Loader;
-use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -41,12 +41,12 @@ final class AppSectionRouteLoader extends Loader
     /**
      * Constructor.
      *
-     * @param LoaderInterface $loader   Route loader
-     * @param array           $sections Sections as associative array, each entry
-     *                                  must contain at least a 'prefix', and optionally
-     *                                  host_pattern, host, host_requirements
+     * @param LoaderResolverInterface $loader   Route loader resolver
+     * @param array                   $sections Sections as associative array, each entry
+     *                                          must contain at least a 'prefix', and optionally
+     *                                          host_pattern, host, host_requirements
      */
-    public function __construct(LoaderInterface $loader, array $sections)
+    public function __construct(LoaderResolverInterface $loader, array $sections)
     {
         $this->sections = $sections;
         $this->loader = $loader;
@@ -76,7 +76,8 @@ final class AppSectionRouteLoader extends Loader
         }
 
         /** @var RouteCollection $collection */
-        $collection = $this->loader->load($parts['resource'], '' === $parts['type'] ? null : $parts['type']);
+        $loader = $this->loader->resolve($parts['resource'], '' === (string) $parts['type'] ? null : $parts['type']);
+        $collection = $loader->load($parts['resource'], '' === (string) $parts['type'] ? null : $parts['type']);
         $section = $this->sections[$parts['section']];
 
         // Configure the section information for all imported routes.

--- a/tests/Functional/Application/AppBundle/AppBundle.php
+++ b/tests/Functional/Application/AppBundle/AppBundle.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks AppSectioningBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle;
+
+use Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle\DependencyInjection\AppExtension;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class AppBundle extends Bundle
+{
+    public function getContainerExtension()
+    {
+        return new AppExtension();
+    }
+}

--- a/tests/Functional/Application/AppBundle/Controller/MainController.php
+++ b/tests/Functional/Application/AppBundle/Controller/MainController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks AppSectioningBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class MainController extends Controller
+{
+    public function fooAction(Request $request)
+    {
+        return new Response('Route: '.$request->attributes->get('_route'));
+    }
+}

--- a/tests/Functional/Application/AppBundle/DependencyInjection/AppExtension.php
+++ b/tests/Functional/Application/AppBundle/DependencyInjection/AppExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks AppSectioningBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle\DependencyInjection;
+
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+final class AppExtension extends Extension
+{
+    const EXTENSION_ALIAS = 'test_app';
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $configuration = $this->getConfiguration($configs, $container);
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $factory = new SectioningFactory($container, 'acme.section');
+        foreach ($config['sections'] as $section => $sectionConfig) {
+            $factory->set($section, $sectionConfig);
+        }
+    }
+
+    public function getAlias(): string
+    {
+        return self::EXTENSION_ALIAS;
+    }
+}

--- a/tests/Functional/Application/AppBundle/DependencyInjection/Configuration.php
+++ b/tests/Functional/Application/AppBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks AppSectioningBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle\DependencyInjection;
+
+use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningConfigurator;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root(AppExtension::EXTENSION_ALIAS);
+
+        $rootNode
+            ->children()
+                ->arrayNode('sections')
+                    ->children()
+                        ->append(SectioningConfigurator::createSection('backend'))
+                        ->append(SectioningConfigurator::createSection('frontend'))
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/backend.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/backend.yml
@@ -1,0 +1,9 @@
+backend_products_show:
+    path: /products/show/{id}
+    defaults: { _controller: "AppBundle:Main:foo" }
+    requirements:
+        id: '\d+'
+
+backend_products_list:
+    path: /products/list
+    defaults: { _controller: "AppBundle:Main:foo" }

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/frontend.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/frontend.yml
@@ -1,0 +1,7 @@
+frontend_products_show:
+    path: /products/show
+    defaults: { _controller: "AppBundle:Main:foo" }
+
+frontend_products_search:
+    path: /products/search
+    defaults: { _controller: "AppBundle:Main:foo" }

--- a/tests/Functional/Application/AppKernel.php
+++ b/tests/Functional/Application/AppKernel.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks AppSectioningBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Kernel;
+
+class AppKernel extends Kernel
+{
+    private $config;
+
+    public function __construct($config, $debug = true)
+    {
+        if (!(new Filesystem())->isAbsolutePath($config)) {
+            $config = __DIR__.'/config/'.$config;
+        }
+
+        if (!file_exists($config)) {
+            throw new \RuntimeException(sprintf('The config file "%s" does not exist.', $config));
+        }
+
+        $this->config = $config;
+
+        parent::__construct('test', $debug);
+    }
+
+    public function getName()
+    {
+        return 'AppSectioning'.substr(sha1($this->config), 0, 3);
+    }
+
+    public function registerBundles()
+    {
+        $bundles = [
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Rollerworks\Bundle\AppSectioning\RollerworksAppSectioningBundle(),
+
+            new AppBundle\AppBundle(),
+        ];
+
+        return $bundles;
+    }
+
+    public function getRootDir()
+    {
+        if (null === $this->rootDir) {
+            $this->rootDir = str_replace('\\', '/', __DIR__);
+        }
+
+        return $this->rootDir;
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load($this->config);
+    }
+
+    public function getCacheDir()
+    {
+        return (getenv('TMPDIR') ?: sys_get_temp_dir()).'/AppSectioning/'.substr(sha1($this->config), 0, 6);
+    }
+
+    public function serialize()
+    {
+        return serialize([$this->config, $this->isDebug()]);
+    }
+
+    public function unserialize($str)
+    {
+        call_user_func_array([$this, '__construct'], unserialize($str));
+    }
+}

--- a/tests/Functional/Application/config/default.yml
+++ b/tests/Functional/Application/config/default.yml
@@ -1,0 +1,15 @@
+imports:
+    - { resource: framework.yml }
+
+test_app:
+    sections:
+        backend:
+            prefix: backend/
+            host: null
+            requirements: ~
+            defaults: ~
+        frontend:
+            prefix: /
+            host: null
+            requirements: ~
+            defaults: ~

--- a/tests/Functional/Application/config/framework.yml
+++ b/tests/Functional/Application/config/framework.yml
@@ -1,0 +1,21 @@
+framework:
+    translator:          false
+    secret:              test
+    router:
+        resource: '%kernel.root_dir%/config/routing.yml'
+        strict_requirements: '%kernel.debug%'
+    form:                false
+    csrf_protection:     false
+    validation:          false
+    templating:          false
+    default_locale:      en
+    session:
+        storage_id: session.storage.mock_file
+    test:                ~
+    assets: false
+    profiler:
+        collect: false
+
+services:
+    logger:
+        class: 'Psr\Log\NullLogger'

--- a/tests/Functional/Application/config/routing.yml
+++ b/tests/Functional/Application/config/routing.yml
@@ -1,0 +1,7 @@
+_backend:
+    resource: 'backend#@AppBundle/Resources/config/routing/backend.yml'
+    type: app_section
+
+_frontend:
+    resource: 'frontend#@AppBundle/Resources/config/routing/frontend.yml'
+    type: app_section

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks AppSectioningBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\AppSectioning\Tests\Functional;
+
+use Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppKernel;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+abstract class FunctionalTestCase extends WebTestCase
+{
+    protected static function createKernel(array $options = []): AppKernel
+    {
+        return new AppKernel($options['config'] ?? 'default.yml');
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return AppKernel::class;
+    }
+
+    protected static function newClient(array $options = [], array $server = []): Client
+    {
+        $client = static::createClient(array_merge(['config' => 'default.yml'], $options), $server);
+
+        $warmer = $client->getContainer()->get('cache_warmer');
+        $warmer->warmUp($client->getContainer()->getParameter('kernel.cache_dir'));
+        $warmer->enableOptionalWarmers();
+
+        return $client;
+    }
+}

--- a/tests/Functional/RouteLoaderTest.php
+++ b/tests/Functional/RouteLoaderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks AppSectioningBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\AppSectioning\Tests\Functional;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class RouteLoaderTest extends FunctionalTestCase
+{
+    /**
+     * @dataProvider provideExpectedImportedRoutes
+     */
+    public function testRoutesToImportedRoutes($uri, $expectedRoute)
+    {
+        $client = self::newClient();
+
+        $client->request('GET', $uri);
+        $this->assertEquals('Route: '.$expectedRoute, $client->getResponse()->getContent());
+    }
+
+    public function testFailsWithNonImportedRoutes()
+    {
+        $client = self::newClient();
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('/noop/products/list');
+
+        $client->request('GET', '/noop/products/list');
+    }
+
+    public function provideExpectedImportedRoutes(): array
+    {
+        return [
+            'frontend_products_show' => ['/products/show', 'frontend_products_show'],
+            'frontend_products_search' => ['/products/search', 'frontend_products_search'],
+
+            'backend_products_list' => ['/backend/products/list', 'backend_products_list'],
+            'backend_products_show' => ['/backend/products/show/1', 'backend_products_show'],
+        ];
+    }
+}

--- a/tests/Routing/AppSectionRouteLoaderTest.php
+++ b/tests/Routing/AppSectionRouteLoaderTest.php
@@ -16,6 +16,7 @@ namespace Rollerworks\Bundle\AppSectioning\Tests\Routing;
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Bundle\AppSectioning\Routing\AppSectionRouteLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -51,8 +52,6 @@ final class AppSectionRouteLoaderTest extends TestCase
     public function createLoader()
     {
         $loader = $this->prophesize(LoaderInterface::class);
-
-        // type=null
         $loader->load('something.yml', null)->will(
             function () {
                 $routeCollection = new RouteCollection();
@@ -63,8 +62,8 @@ final class AppSectionRouteLoaderTest extends TestCase
             }
         );
 
-        // type=xml
-        $loader->load('something.xml', 'xml')->will(
+        $xmlLoader = $this->prophesize(LoaderInterface::class);
+        $xmlLoader->load('something.xml', 'xml')->will(
             function () {
                 $routeCollection = new RouteCollection();
                 $routeCollection->add('backend_main', new Route('/'));
@@ -74,7 +73,11 @@ final class AppSectionRouteLoaderTest extends TestCase
             }
         );
 
-        $this->loader = new AppSectionRouteLoader($loader->reveal(), self::APP_SECTIONS);
+        $resolver = $this->prophesize(LoaderResolverInterface::class);
+        $resolver->resolve('something.yml', null)->willReturn($loader);
+        $resolver->resolve('something.xml', 'xml')->willReturn($xmlLoader);
+
+        $this->loader = new AppSectionRouteLoader($resolver->reveal(), self::APP_SECTIONS);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #10 
| License       | MIT

Use LoaderResolver instead of the Loader directly. And add more tests (including Functional)
to prevent future regressions.

**Note dep=low is disabled due to compatibility problems. Next minor will remove support for Symfony 2.x completely.**