### PR TITLE
Change namespace to include bundle name and drop Symfony 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ branches:
 matrix:
     include:
         - php: '7.1'
-#        - php: '7.1'
-#          env: deps='low'
+        - php: '7.1'
+          env: deps='low'
         - php: '7.1'
           env: deps='dev'
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,8 @@ UPGRADE
 
 * The namespace has changed from `Rollerworks\Bundle\AppSectioning`
   to `Rollerworks\Bundle\AppSectioningBundle` to make Symfony Flex work.
+  
+* Support for Symfony 2.8 was dropped, you now need at least Symfony 3.2
 
 ## Upgrade FROM 0.2 to 0.3
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,11 @@
 UPGRADE
 =======
 
+## Upgrade FROM 0.3 to 0.4
+
+* The namespace has changed from `Rollerworks\Bundle\AppSectioning`
+  to `Rollerworks\Bundle\AppSectioningBundle` to make Symfony Flex work.
+
 ## Upgrade FROM 0.2 to 0.3
 
 The vendor-namespace changed to `Rollerworks`.

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/framework-bundle": "^2.8.9|^3.2.8",
+        "symfony/framework-bundle": "^3.2.8",
         "icomefromthenet/reverse-regex": "^0.0.6.3"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.2.6",
-        "symfony/browser-kit": "^2.8.9 || ^3.2.8",
-        "matthiasnoback/symfony-dependency-injection-test": "^2.0.0"
+        "symfony/phpunit-bridge": "^3.2.8",
+        "symfony/browser-kit": "^3.2.8",
+        "matthiasnoback/symfony-dependency-injection-test": "^2.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,18 +21,18 @@
     },
     "autoload": {
         "psr-4": {
-            "Rollerworks\\Bundle\\AppSectioning\\": "src/"
+            "Rollerworks\\Bundle\\AppSectioningBundle\\": "src/"
         },
         "exclude-from-classmap": ["test/"]
     },
     "autoload-dev": {
         "psr-4": {
-            "Rollerworks\\Bundle\\AppSectioning\\Tests\\": "tests/"
+            "Rollerworks\\Bundle\\AppSectioningBundle\\Tests\\": "tests/"
         }
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.3-dev"
+            "dev-master": "0.4-dev"
         }
     }
 }

--- a/src/AppSectionsValidator.php
+++ b/src/AppSectionsValidator.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning;
+namespace Rollerworks\Bundle\AppSectioningBundle;
 
-use Rollerworks\Bundle\AppSectioning\Exception\ValidatorException;
+use Rollerworks\Bundle\AppSectioningBundle\Exception\ValidatorException;
 
 /**
  * The AppSectionsValidator validates whether the provided Application sections

--- a/src/DependencyInjection/AppSectionExtension.php
+++ b/src/DependencyInjection/AppSectionExtension.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioningBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/DependencyInjection/Compiler/AppSectionsPass.php
+++ b/src/DependencyInjection/Compiler/AppSectionsPass.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\DependencyInjection\Compiler;
+namespace Rollerworks\Bundle\AppSectioningBundle\DependencyInjection\Compiler;
 
-use Rollerworks\Bundle\AppSectioning\AppSectionsValidator;
-use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
-use Rollerworks\Bundle\AppSectioning\SectionsConfigurator;
+use Rollerworks\Bundle\AppSectioningBundle\AppSectionsValidator;
+use Rollerworks\Bundle\AppSectioningBundle\DependencyInjection\SectioningFactory;
+use Rollerworks\Bundle\AppSectioningBundle\SectionsConfigurator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 

--- a/src/DependencyInjection/SectioningConfigurator.php
+++ b/src/DependencyInjection/SectioningConfigurator.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioningBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/DependencyInjection/SectioningFactory.php
+++ b/src/DependencyInjection/SectioningFactory.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioningBundle\DependencyInjection;
 
-use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioningBundle\SectionConfiguration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 

--- a/src/Exception/ValidatorException.php
+++ b/src/Exception/ValidatorException.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Exception;
+namespace Rollerworks\Bundle\AppSectioningBundle\Exception;
 
 final class ValidatorException extends \LogicException
 {

--- a/src/RegexEqualityChecker.php
+++ b/src/RegexEqualityChecker.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning;
+namespace Rollerworks\Bundle\AppSectioningBundle;
 
 use ReverseRegex\Generator\Scope;
 use ReverseRegex\Lexer;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="rollerworks.app_section.route_loader" class="Rollerworks\Bundle\AppSectioning\Routing\AppSectionRouteLoader" public="false">
+        <service id="rollerworks.app_section.route_loader" class="Rollerworks\Bundle\AppSectioningBundle\Routing\AppSectionRouteLoader" public="false">
             <tag name="routing.loader" />
             <argument type="service" id="routing.resolver" />
             <argument type="collection" /> <!-- Gets populated by the AppSectionsPass -->

--- a/src/RollerworksAppSectioningBundle.php
+++ b/src/RollerworksAppSectioningBundle.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning;
+namespace Rollerworks\Bundle\AppSectioningBundle;
 
-use Rollerworks\Bundle\AppSectioning\DependencyInjection\AppSectionExtension;
-use Rollerworks\Bundle\AppSectioning\DependencyInjection\Compiler\AppSectionsPass;
+use Rollerworks\Bundle\AppSectioningBundle\DependencyInjection\AppSectionExtension;
+use Rollerworks\Bundle\AppSectioningBundle\DependencyInjection\Compiler\AppSectionsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/src/Routing/AppSectionRouteLoader.php
+++ b/src/Routing/AppSectionRouteLoader.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Routing;
+namespace Rollerworks\Bundle\AppSectioningBundle\Routing;
 
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;

--- a/src/SectionConfiguration.php
+++ b/src/SectionConfiguration.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning;
+namespace Rollerworks\Bundle\AppSectioningBundle;
 
 use Symfony\Component\Routing\Route;
 

--- a/src/SectionsConfigurator.php
+++ b/src/SectionsConfigurator.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning;
+namespace Rollerworks\Bundle\AppSectioningBundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\RequestMatcher;

--- a/tests/AppSectionsValidatorTest.php
+++ b/tests/AppSectionsValidatorTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Bundle\AppSectioning\AppSectionsValidator;
-use Rollerworks\Bundle\AppSectioning\Exception\ValidatorException;
-use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioningBundle\AppSectionsValidator;
+use Rollerworks\Bundle\AppSectioningBundle\Exception\ValidatorException;
+use Rollerworks\Bundle\AppSectioningBundle\SectionConfiguration;
 
 final class AppSectionsValidatorTest extends TestCase
 {

--- a/tests/DependencyInjection/Compiler/AppSectionsPassTest.php
+++ b/tests/DependencyInjection/Compiler/AppSectionsPassTest.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\DependencyInjection\Compiler;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
-use Rollerworks\Bundle\AppSectioning\DependencyInjection\Compiler\AppSectionsPass;
-use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
-use Rollerworks\Bundle\AppSectioning\Exception\ValidatorException;
-use Rollerworks\Bundle\AppSectioning\Routing\AppSectionRouteLoader;
+use Rollerworks\Bundle\AppSectioningBundle\DependencyInjection\Compiler\AppSectionsPass;
+use Rollerworks\Bundle\AppSectioningBundle\DependencyInjection\SectioningFactory;
+use Rollerworks\Bundle\AppSectioningBundle\Exception\ValidatorException;
+use Rollerworks\Bundle\AppSectioningBundle\Routing\AppSectionRouteLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;

--- a/tests/DependencyInjection/SectioningFactoryTest.php
+++ b/tests/DependencyInjection/SectioningFactoryTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractContainerBuilderTestCase;
-use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
-use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioningBundle\DependencyInjection\SectioningFactory;
+use Rollerworks\Bundle\AppSectioningBundle\SectionConfiguration;
 
 final class SectioningFactoryTest extends AbstractContainerBuilderTestCase
 {
@@ -76,7 +76,7 @@ final class SectioningFactoryTest extends AbstractContainerBuilderTestCase
         $this->assertSame($factory, $factory->set('frontend', ['prefix' => '/', 'host' => 'example.com']));
         $this->assertSame($factory, $factory->set('backend', ['prefix' => 'backend', 'host' => 'example.com']));
 
-        $factory = new SectioningFactory($this->container, 'rollerworks.section', 'second');
+        $factory = new SectioningFactory($this->container, 'rollerworks.section');
         $this->assertSame($factory, $factory->set('frontend', ['prefix' => '/', 'host' => 'example.com']));
         $this->assertSame($factory, $factory->set('backend', ['prefix' => 'backend', 'host' => 'example.com']));
 

--- a/tests/Functional/Application/AppBundle/AppBundle.php
+++ b/tests/Functional/Application/AppBundle/AppBundle.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\Functional\Application\AppBundle;
 
-use Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle\DependencyInjection\AppExtension;
+use Rollerworks\Bundle\AppSectioningBundle\Tests\Functional\Application\AppBundle\DependencyInjection\AppExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class AppBundle extends Bundle

--- a/tests/Functional/Application/AppBundle/Controller/MainController.php
+++ b/tests/Functional/Application/AppBundle/Controller/MainController.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle\Controller;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\Functional\Application\AppBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/Functional/Application/AppBundle/DependencyInjection/AppExtension.php
+++ b/tests/Functional/Application/AppBundle/DependencyInjection/AppExtension.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\Functional\Application\AppBundle\DependencyInjection;
 
-use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningFactory;
+use Rollerworks\Bundle\AppSectioningBundle\DependencyInjection\SectioningFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 

--- a/tests/Functional/Application/AppBundle/DependencyInjection/Configuration.php
+++ b/tests/Functional/Application/AppBundle/DependencyInjection/Configuration.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppBundle\DependencyInjection;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\Functional\Application\AppBundle\DependencyInjection;
 
-use Rollerworks\Bundle\AppSectioning\DependencyInjection\SectioningConfigurator;
+use Rollerworks\Bundle\AppSectioningBundle\DependencyInjection\SectioningConfigurator;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 

--- a/tests/Functional/Application/AppKernel.php
+++ b/tests/Functional/Application/AppKernel.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\Functional\Application;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\Functional\Application;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -45,7 +45,7 @@ class AppKernel extends Kernel
     {
         $bundles = [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new \Rollerworks\Bundle\AppSectioning\RollerworksAppSectioningBundle(),
+            new \Rollerworks\Bundle\AppSectioningBundle\RollerworksAppSectioningBundle(),
 
             new AppBundle\AppBundle(),
         ];

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\Functional;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\Functional;
 
-use Rollerworks\Bundle\AppSectioning\Tests\Functional\Application\AppKernel;
+use Rollerworks\Bundle\AppSectioningBundle\Tests\Functional\Application\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 

--- a/tests/Functional/RouteLoaderTest.php
+++ b/tests/Functional/RouteLoaderTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\Functional;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\Functional;
 
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 

--- a/tests/RegexEqualityCheckerTest.php
+++ b/tests/RegexEqualityCheckerTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Bundle\AppSectioning\RegexEqualityChecker;
+use Rollerworks\Bundle\AppSectioningBundle\RegexEqualityChecker;
 
 final class RegexEqualityCheckerTest extends TestCase
 {

--- a/tests/Routing/AppSectionRouteLoaderTest.php
+++ b/tests/Routing/AppSectionRouteLoaderTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests\Routing;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests\Routing;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Bundle\AppSectioning\Routing\AppSectionRouteLoader;
+use Rollerworks\Bundle\AppSectioningBundle\Routing\AppSectionRouteLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\Routing\Route;

--- a/tests/SectionConfigurationTest.php
+++ b/tests/SectionConfigurationTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioningBundle\SectionConfiguration;
 
 final class SectionConfigurationTest extends TestCase
 {

--- a/tests/SectionsConfiguratorTest.php
+++ b/tests/SectionsConfiguratorTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Bundle\AppSectioning\Tests;
+namespace Rollerworks\Bundle\AppSectioningBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Bundle\AppSectioning\SectionConfiguration;
-use Rollerworks\Bundle\AppSectioning\SectionsConfigurator;
+use Rollerworks\Bundle\AppSectioningBundle\SectionConfiguration;
+use Rollerworks\Bundle\AppSectioningBundle\SectionsConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Symfony Flex (without a recipe) is currently unable to guess the correct Bundle name, so this changed include the Bundle name (completely).

And support for Symfony 2.8 is dropped because this was causing some issues with testing deps=low.